### PR TITLE
better handling for parsing response

### DIFF
--- a/coconut.js
+++ b/coconut.js
@@ -38,7 +38,13 @@ module.exports = {
       });
 
       res.on('end', function () {
-        var resultObject = JSON.parse(responseString);
+        var resultObject;
+        try {
+          resultObject = JSON.parse(responseString);
+        } catch(error) {
+          resultObject = null;
+        }
+
         if(callback) {
           callback(resultObject);
         }


### PR DESCRIPTION
`<h1>This website is under heavy load</h1>` can cause JSON parse failures.