### PR TITLE
Return a Promise if no callback is set for createJob

### DIFF
--- a/coconut.js
+++ b/coconut.js
@@ -98,6 +98,12 @@ module.exports = {
     return new_conf.join('\n');
   },
   createJob: function(options, callback) {
+    if (typeof callback === 'undefined') {
+      return new Promise(function(resolve) {
+        module.exports.submit(module.exports.config(options), options.api_key, resolve);
+      });
+    }
+
     this.submit(this.config(options), options.api_key, callback);
   }
 }


### PR DESCRIPTION
If no callback is set for `createJob`, then return a Promise.

This allows for better integration with existing Promise-based code.

Example:

```
function transcode() {
  coconutjs.createJob(options).then(function(job) {
    // job.status, job.id etc.
  })
}
```

Using `async`/`await`:
```
async function transcode() {
  const job = await coconutjs.createJob(options);
  // job.status, job.id etc.
}
```
