### PR TITLE
Move nodeunit to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "author": "Bruno Celeste",
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
     "nodeunit": "^0.11.3"
   }
 }


### PR DESCRIPTION
Move `nodeunit` to `devDependencies` as testing is only needed for local development, and removes unwanted packages being installed on production.

See https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file.