### PR TITLE
Handle server errors that do not return a JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,13 @@ coconut.createJob({
   'source': 'https://s3-eu-west-1.amazonaws.com/files.coconut.co/test.mp4',
   'vars': {'vid': 1234}
 }, function(job) {
-  if(job.status == 'ok') {
+  if(job && job.status == 'ok') {
     console.log(job.id);
-  } else {
+  } else if (job) {
     console.log(job.error_code);
     console.log(job.error_message);
+  } else {
+    console.log('Error creating job')
   }
 });
 ```

--- a/coconut.js
+++ b/coconut.js
@@ -42,7 +42,7 @@ module.exports = {
         try {
           resultObject = JSON.parse(responseString);
         } catch(e) {
-          console.log('problem with request: ' + e);
+          console.log('problem with request: ' + e.message);
         }
         if(callback) {
           callback(resultObject);
@@ -94,7 +94,7 @@ module.exports = {
         try {
           resultObject = JSON.parse(responseString);
         } catch(e) {
-          console.log('problem with request: ' + e);
+          console.log('problem with request: ' + e.message);
         }
         if(callback) {
           callback(resultObject);

--- a/coconut.js
+++ b/coconut.js
@@ -38,7 +38,12 @@ module.exports = {
       });
 
       res.on('end', function () {
-        var resultObject = JSON.parse(responseString);
+        var resultObject = null;
+        try {
+          resultObject = JSON.parse(responseString);
+        } catch(e) {
+          console.log('problem with request: ' + e);
+        }
         if(callback) {
           callback(resultObject);
         }
@@ -85,7 +90,12 @@ module.exports = {
       });
 
       res.on('end', function () {
-        var resultObject = JSON.parse(responseString);
+        var resultObject = null;
+        try {
+          resultObject = JSON.parse(responseString);
+        } catch(e) {
+          console.log('problem with request: ' + e);
+        }
         if(callback) {
           callback(resultObject);
         }


### PR DESCRIPTION
When there is a network error or the Coconut server fails to respond with a JSON response, the `JSON.parse` crashes and the error is not caught. This makes the coconut library to never resolve nor call back.

I have added a `try ... catch...` clause around the JSON parsing. On error, it will return `null` like it does for `req.on('error')`.

Also, updated the documentation since it was assuming that the callback always receives a `job` object. It can also receive `null` on error.